### PR TITLE
fix: add open3d and opencv_python to fix dependence

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ scipy
 scikit-learn
 matplotlib
 ipykernel
+open3d
+opencv_python


### PR DESCRIPTION
When I followed the `README.md` to run `wurTomato.py`, I got :

```
$ python3 wurTomato.py --visualise 0
Traceback (most recent call last):
  File "/home/yiming/Code/Machine Learning/TomatoWUR/wurTomato.py", line 31, in <module>
    from scripts.utils_data import create_skeleton_gt_data
  File "/home/yiming/Code/Machine Learning/TomatoWUR/scripts/utils_data.py", line 6, in <module>
    import open3d as o3d
ModuleNotFoundError: No module named 'open3d'
(TomatoWUR) 

$ python3 wurTomato.py --visualise 0
Traceback (most recent call last):
  File "/home/yiming/Code/Machine Learning/TomatoWUR/wurTomato.py", line 31, in <module>
    from scripts.utils_data import create_skeleton_gt_data
  File "/home/yiming/Code/Machine Learning/TomatoWUR/scripts/utils_data.py", line 7, in <module>
    import cv2
ModuleNotFoundError: No module named 'cv2'
(TomatoWUR) 

```

Then I found `open3d` and `opencv_python` missing in `requirements.txt`. I added them to the file. All fixed.

Then I opened a PR to fix the dependence problem.